### PR TITLE
Fixes and a preparation for a Ports option to turn off setuid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,22 @@ intel_backlight: $(SRC)
 	$(CC) -o intel_backlight $(INCS) $(LIBS) $(SRC) $(CFLAGS) $(LDFLAGS)
 	strip intel_backlight
 
-install: intel_backlight
-	mkdir -p "$(DESTDIR)$(PREFIX)/bin"
-	install -m4555 intel_backlight "$(DESTDIR)$(PREFIX)/bin"
+install-man:
 	mkdir -p "$(DESTDIR)$(MANPREFIX)/man/man1"
 	install -m0444 intel_backlight.1 "$(DESTDIR)$(MANPREFIX)/man/man1"
 
+install: intel_backlight install-man
+	mkdir -p "$(DESTDIR)$(PREFIX)/bin"
+	install -m0555 intel_backlight "$(DESTDIR)$(PREFIX)/bin"
+
 install-strip: install
+	strip "$(DESTDIR)$(PREFIX)/bin/intel_backlight"
+
+install-setuid: intel_backlight install-man
+	mkdir -p "$(DESTDIR)$(PREFIX)/bin"
+	install -m4555 intel_backlight "$(DESTDIR)$(PREFIX)/bin"
+
+install-setuid-strip: install
 	strip "$(DESTDIR)$(PREFIX)/bin/intel_backlight"
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ intel_backlight: $(SRC)
 install: intel_backlight
 	mkdir -p "$(DESTDIR)$(PREFIX)/bin"
 	install -m4555 intel_backlight "$(DESTDIR)$(PREFIX)/bin"
-	mkdir -p "${MANPREFIX}/man/man1"
-	install -m0444 intel_backlight.1 "${MANPREFIX}/man/man1"
+	mkdir -p "$(DESTDIR)$(MANPREFIX)/man/man1"
+	install -m0444 intel_backlight.1 "$(DESTDIR)$(MANPREFIX)/man/man1"
 
 install-strip: install
 	strip "$(DESTDIR)$(PREFIX)/bin/intel_backlight"

--- a/README
+++ b/README
@@ -9,7 +9,7 @@ Originally ported to FreeBSD by "emmex" of the FreeBSD forums.
 Build:
   pkg install libpciaccess libdrm
   make
-  make install
+  make install-setuid-strip
 
 (this installs intel_backlight setuid root, so any user can execute it).
 

--- a/intel_backlight.1
+++ b/intel_backlight.1
@@ -58,6 +58,11 @@ backlight back to the default value of 100.
 .El
 .Sh FILES
 .Bl -tag -width ".Pa /dev/null" -compact
+.It Pa /usr/local/share/examples/intel-backlight/asmc_backlight.sh
+An example of a script adjusting brightness automatically based on the
+input of the MacBook
+.Xr asmc 4
+light sensor driver.
 .It Pa /usr/local/share/examples/intel-backlight/isl_backlight.sh
 An example of a script adjusting brightness automatically based on the
 input of the
@@ -84,6 +89,7 @@ in the source distribution of
 for a list of supported chipsets.
 .Sh SEE ALSO
 .Xr acpi_video 4 ,
+.Xr asmc 4 ,
 .Xr isl 4
 .Sh HISTORY
 Originally ported to 

--- a/intel_backlight.1
+++ b/intel_backlight.1
@@ -68,7 +68,7 @@ driver, which is currently not part of standard
 .Sh EXIT STATUS
 .Ex -std
 .Sh DIAGNOSTICS
-The command may fail for one of the following reasons:
+The command may fail for any of the following reasons:
 .Bl -diag
 .It "Couldn't initialize PCI system: Device not configured"
 The user does not have required permissions to execute


### PR DESCRIPTION
* I'm sorry, I missed this one during my tests. I discovered it only now as I'm preparing a port update.
* There's also an update to the manual as suggested by gnn@.
* Also, as you requested in #1 , I'm working on providing an option to disable setuid when those updates reach the port. It requires some changes, which are included in 546309d.
* Add a reference to `asmc_backlight.sh` to the manpage.

Cheers! :) 